### PR TITLE
Add comment functionality to to_csv method and associated tests #59839

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3674,6 +3674,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         decimal: str = ...,
         errors: OpenFileErrors = ...,
         storage_options: StorageOptions = ...,
+        comment: Sequence[str] | None = ...,
+        commentchar: str = ...,
     ) -> str: ...
 
     @overload
@@ -3701,6 +3703,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         decimal: str = ...,
         errors: OpenFileErrors = ...,
         storage_options: StorageOptions = ...,
+        comment: Sequence[str] | None = ..., # GH#59839
+        commentchar: str = ..., # GH#59839
     ) -> None: ...
 
     @final
@@ -3732,6 +3736,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         decimal: str = ".",
         errors: OpenFileErrors = "strict",
         storage_options: StorageOptions | None = None,
+        comment: Sequence[str] | None = None, # GH#59839
+        commentchar: str = '#', # GH#59839
     ) -> str | None:
         r"""
         Write object to a comma-separated values (csv) file.
@@ -3819,6 +3825,14 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
         {storage_options}
 
+        -------
+        # GH#59839
+        comment : list-like of str, optional
+            Lines to be inserted as comments between the header and the data.
+        comment_char : str, default '#'
+            Character used to prefix each comment line.
+        -------
+
         Returns
         -------
         None or str
@@ -3891,6 +3905,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             doublequote=doublequote,
             escapechar=escapechar,
             storage_options=storage_options,
+            comment=comment, # GH#59839
+            commentchar=commentchar # GH#59839
         )
 
     # ----------------------------------------------------------------------
@@ -8201,7 +8217,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                 return self._clip_with_scalar(None, threshold, inplace=inplace)
             return self._clip_with_scalar(threshold, None, inplace=inplace)
 
-        # GH #15390
+        # GH#15390
         # In order for where method to work, the threshold must
         # be transformed to NDFrame from other array like structure.
         if (not isinstance(threshold, ABCSeries)) and is_list_like(threshold):

--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -75,6 +75,8 @@ class CSVFormatter:
         doublequote: bool = True,
         escapechar: str | None = None,
         storage_options: StorageOptions | None = None,
+        comment: Sequence[str] | None = None, # GH#59839
+        commentchar: str = '#', # GH#59839
     ) -> None:
         self.fmt = formatter
 
@@ -85,6 +87,8 @@ class CSVFormatter:
         self.compression: CompressionOptions = compression
         self.mode = mode
         self.storage_options = storage_options
+        self.comment = comment # GH#59839
+        self.commentchar = commentchar # GH#59839
 
         self.sep = sep
         self.index_label = self._initialize_index_label(index_label)
@@ -272,6 +276,9 @@ class CSVFormatter:
     def _save(self) -> None:
         if self._need_to_save_header:
             self._save_header()
+        # GH#59839
+        if self.comment:
+            self._save_comments()
         self._save_body()
 
     def _save_header(self) -> None:
@@ -332,3 +339,10 @@ class CSVFormatter:
             self.cols,
             self.writer,
         )
+
+    # GH#59839
+    def _save_comments(self) -> None:
+        num_columns = len(self.encoded_labels)
+        for comment_line in self.comment:
+            row = [f"{self.commentchar} {comment_line}"] + [""] * (num_columns - 1)
+            self.writer.writerow(row)

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -963,6 +963,8 @@ class DataFrameRenderer:
         escapechar: str | None = None,
         errors: str = "strict",
         storage_options: StorageOptions | None = None,
+        comment: Sequence[str] | None = None, # GH#59839
+        commentchar: str = '#', # GH#59839
     ) -> str | None:
         """
         Render dataframe as comma-separated file.
@@ -992,6 +994,8 @@ class DataFrameRenderer:
             doublequote=doublequote,
             escapechar=escapechar,
             storage_options=storage_options,
+            comment=comment, # GH#59839
+            commentchar=commentchar, # GH#59839
             formatter=self.fmt,
         )
         csv_formatter.save()

--- a/pandas/tests/io/formats/test_to_csv.py
+++ b/pandas/tests/io/formats/test_to_csv.py
@@ -744,3 +744,20 @@ def test_to_csv_iterative_compression_buffer(compression):
             pd.read_csv(buffer, compression=compression, index_col=0), df
         )
         assert not buffer.closed
+
+def test_to_csv_with_comments():
+    # GH#59839
+    df = DataFrame({"col1": [1,2], "col2": [3,4]})
+    expected = """\
+col1,col2
+# This is a comment,
+1,3
+2,4
+"""
+    comments = ["This is a comment"]
+    with tm.ensure_clean("test_with_comments.csv") as path:
+        df.to_csv(path, comment=comments, index=False)
+        with open(path, encoding="utf-8") as f:
+            result = f.read()
+            print('\n',result,'\n')
+            assert result == expected


### PR DESCRIPTION
pandas/core/generic.py:

- Modified the to_csv method to support two new arguments: comment and commentchar, allowing users to prepend comments to CSV files during export with custom comment characters if desired (defaults to '#').

pandas/io/formats/csvs.py:

- Added logic to handle the writing of comment lines before data rows when the comment argument is provided.
- Ensured the correct format of comments, properly aligned with the number of columns.

pandas/io/formats/format.py:

- Updated the internal format renderer to accommodate the changes for handling comments in the CSV output.

pandas/tests/io/formats/test_to_csv.py:

- Added new test to validate the functionality of the comment argument in the to_csv method.
- Ensured comments are correctly written in the expected format.
